### PR TITLE
Update 1275 Find Winner on a Tic Tac Toe Game - Change break to continue

### DIFF
--- a/src/main/kotlin/g1201_1300/s1275_find_winner_on_a_tic_tac_toe_game/readme.md
+++ b/src/main/kotlin/g1201_1300/s1275_find_winner_on_a_tic_tac_toe_game/readme.md
@@ -78,7 +78,7 @@ class Solution {
     private fun wins(board: Array<Array<String?>>): String {
         for (i in 0..2) {
             if (board[i][0] == null) {
-                break
+                continue
             }
             val str = board[i][0]
             if (str == board[i][1] && str == board[i][2]) {
@@ -87,7 +87,7 @@ class Solution {
         }
         for (j in 0..2) {
             if (board[0][j] == null) {
-                break
+                continue
             }
             val str = board[0][j]
             if (str == board[1][j] && str == board[2][j]) {


### PR DESCRIPTION
Tic Tac Toe solution used `break` inside a loop when the first cell of the column or row was empty. I believe this will result in it skipping all other rows/columns when it reaches a null cell. Instead of using `break` I think it should be `continue` instead.

Tested locally and `continue` works for 3 vertical in the last column, where `break` fails to find the winner.